### PR TITLE
Add support for Semaphore CI 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,81 +318,20 @@ test_ci_node_1:
 - If you have 2 parallel jobs you need to set `KNAPSACK_PRO_CI_NODE_TOTAL=2` for each job.
 - You need to set job index starting from 0 like `KNAPSACK_PRO_CI_NODE_INDEX=0` for Node 0.
 
-Below you can find full Semaphore CI 2.0 config for Rails project.
+Below you can find example part of Semaphore CI 2.0 config.
 
 ```yaml
-# .semaphore/semaphore.yml
-# Use the latest stable version of Semaphore 2.0 YML syntax:
-version: v1.0
-
-# Name your pipeline. In case you connect multiple pipelines with promotions,
-# the name will help you differentiate between, for example, a CI build phase
-# and delivery phases.
-name: Demo Rails 5 app
-
-# An agent defines the environment in which your code runs.
-# It is a combination of one of available machine types and operating
-# system images.
-# See https://docs.semaphoreci.com/article/20-machine-types
-# and https://docs.semaphoreci.com/article/32-ubuntu-1804-image
-agent:
-  machine:
-    type: e1-standard-2
-    os_image: ubuntu1804
-
-# Blocks are the heart of a pipeline and are executed sequentially.
-# Each block has a task that defines one or more jobs. Jobs define the
-# commands to execute.
-# See https://docs.semaphoreci.com/article/62-concepts
 blocks:
-  - name: Setup
-    task:
-      env_vars:
-        - name: RAILS_ENV
-          value: test
-      jobs:
-        - name: bundle
-          commands:
-            # Checkout code from Git repository. This step is mandatory if the
-            # job is to work with your code.
-            # Optionally you may use --use-cache flag to avoid roundtrip to
-            # remote repository.
-            # See https://docs.semaphoreci.com/article/54-toolbox-reference#libcheckout
-            - checkout
-            # Restore dependencies from cache.
-            # Read about caching: https://docs.semaphoreci.com/article/54-toolbox-reference#cache
-            - cache restore gems-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock),gems-$SEMAPHORE_GIT_BRANCH-,gems-master-
-            # Set Ruby version:
-            - sem-version ruby 2.6.1
-            - bundle install --jobs=4 --retry=3 --path vendor/bundle
-            # Store the latest version of dependencies in cache,
-            # to be used in next blocks and future workflows:
-            - cache store gems-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock) vendor/bundle
-
   - name: Cypress tests
     task:
       env_vars:
-        - name: RAILS_ENV
-          value: test
-        - name: PGHOST
-          value: 127.0.0.1
-        - name: PGUSER
-          value: postgres
         - name: KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS
           value: your_api_token_here
-      # This block runs two jobs in parallel and they both share common
-      # setup steps. We can group them in a prologue.
-      # See https://docs.semaphoreci.com/article/50-pipeline-yaml#prologue
       prologue:
         commands:
           - checkout
-          - cache restore gems-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock),gems-$SEMAPHORE_GIT_BRANCH-,gems-master-
-          # Start Postgres database service.
-          # See https://docs.semaphoreci.com/article/54-toolbox-reference#sem-service
-          - sem-service start postgres
-          - sem-version ruby 2.6.1
-          - bundle install --jobs=4 --retry=3 --path vendor/bundle
-          - bundle exec rake db:setup
+          - nvm install --lts carbon
+          - sem-version node --lts carbon
 
       jobs:
         - name: Node 0 - Knapsack Pro

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Read article about [runnning javascript E2E tests faster with Cypress on paralle
       - [GitLab CI `>= 11.5`](#gitlab-ci--115)
       - [GitLab CI `< 11.5` (old GitLab CI)](#gitlab-ci--115-old-gitlab-ci)
     - [SemaphoreCI.com](#semaphorecicom)
+      - [Semaphore 2.0](#semaphore-20)
+      - [Semaphore 1.0](#semaphore-10)
     - [Cirrus-CI.org](#cirrus-ciorg)
     - [Jenkins](#jenkins)
     - [Other CI provider](#other-ci-provider)

--- a/README.md
+++ b/README.md
@@ -309,6 +309,103 @@ test_ci_node_1:
 
 #### SemaphoreCI.com
 
+##### Semaphore 2.0
+
+`@knapsack-pro/cypress` supports environment variables provided by Semaphore CI 2.0 to run your tests. You will have to define a few things in `.semaphore/semaphore.yml` config file.
+
+- You need to set `KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS`. If you don't want to commit secrets in yml file then you can [follow this guide](https://docs.semaphoreci.com/article/66-environment-variables-and-secrets).
+- You need to create as many jobs with unique names (Node 0 - Knapsack Pro, Node 1 - Knapsack Pro etc) as many parallel jobs you want to run. If your test suite is long you should use more parallel jobs.
+- If you have 2 parallel jobs you need to set `KNAPSACK_PRO_CI_NODE_TOTAL=2` for each job.
+- You need to set job index starting from 0 like `KNAPSACK_PRO_CI_NODE_INDEX=0` for Node 0.
+
+Below you can find full Semaphore CI 2.0 config for Rails project.
+
+```yaml
+# .semaphore/semaphore.yml
+# Use the latest stable version of Semaphore 2.0 YML syntax:
+version: v1.0
+
+# Name your pipeline. In case you connect multiple pipelines with promotions,
+# the name will help you differentiate between, for example, a CI build phase
+# and delivery phases.
+name: Demo Rails 5 app
+
+# An agent defines the environment in which your code runs.
+# It is a combination of one of available machine types and operating
+# system images.
+# See https://docs.semaphoreci.com/article/20-machine-types
+# and https://docs.semaphoreci.com/article/32-ubuntu-1804-image
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+# Blocks are the heart of a pipeline and are executed sequentially.
+# Each block has a task that defines one or more jobs. Jobs define the
+# commands to execute.
+# See https://docs.semaphoreci.com/article/62-concepts
+blocks:
+  - name: Setup
+    task:
+      env_vars:
+        - name: RAILS_ENV
+          value: test
+      jobs:
+        - name: bundle
+          commands:
+            # Checkout code from Git repository. This step is mandatory if the
+            # job is to work with your code.
+            # Optionally you may use --use-cache flag to avoid roundtrip to
+            # remote repository.
+            # See https://docs.semaphoreci.com/article/54-toolbox-reference#libcheckout
+            - checkout
+            # Restore dependencies from cache.
+            # Read about caching: https://docs.semaphoreci.com/article/54-toolbox-reference#cache
+            - cache restore gems-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock),gems-$SEMAPHORE_GIT_BRANCH-,gems-master-
+            # Set Ruby version:
+            - sem-version ruby 2.6.1
+            - bundle install --jobs=4 --retry=3 --path vendor/bundle
+            # Store the latest version of dependencies in cache,
+            # to be used in next blocks and future workflows:
+            - cache store gems-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock) vendor/bundle
+
+  - name: Cypress tests
+    task:
+      env_vars:
+        - name: RAILS_ENV
+          value: test
+        - name: PGHOST
+          value: 127.0.0.1
+        - name: PGUSER
+          value: postgres
+        - name: KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS
+          value: your_api_token_here
+      # This block runs two jobs in parallel and they both share common
+      # setup steps. We can group them in a prologue.
+      # See https://docs.semaphoreci.com/article/50-pipeline-yaml#prologue
+      prologue:
+        commands:
+          - checkout
+          - cache restore gems-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock),gems-$SEMAPHORE_GIT_BRANCH-,gems-master-
+          # Start Postgres database service.
+          # See https://docs.semaphoreci.com/article/54-toolbox-reference#sem-service
+          - sem-service start postgres
+          - sem-version ruby 2.6.1
+          - bundle install --jobs=4 --retry=3 --path vendor/bundle
+          - bundle exec rake db:setup
+
+      jobs:
+        - name: Node 0 - Knapsack Pro
+          commands:
+            - KNAPSACK_PRO_CI_NODE_TOTAL=2 KNAPSACK_PRO_CI_NODE_INDEX=0 $(npm bin)/knapsack-pro-cypress
+
+        - name: Node 1 - Knapsack Pro
+          commands:
+            - KNAPSACK_PRO_CI_NODE_TOTAL=2 KNAPSACK_PRO_CI_NODE_INDEX=1 $(npm bin)/knapsack-pro-cypress
+```
+
+##### Semaphore 1.0
+
 The only thing you need to do is set up `@knapsack-pro/cypress` for as many parallel threads as you need. Here is an example:
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -855,9 +855,9 @@
       }
     },
     "@knapsack-pro/core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-2emYNXjROgi9mgeH7sBI5GW5oxPdOw5DXeZ7YZTblbo0A63J+8NEDeSrzMzKVhL+9i4nnCacsIB8HwjVcxmWKA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-63kJpA4gEcSLLibQaKGr/nEKY2CZWkKYYKpIU8vtFCRu9ORIjX0k5rdp+0Gsckdm/QmJ/S4F7GxH0HZu+sFWrQ==",
       "requires": {
         "axios": "^0.18.0",
         "axios-retry": "^3.1.1",
@@ -1705,7 +1705,7 @@
     },
     "axios": {
       "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
         "follow-redirects": "^1.3.0",
@@ -2943,7 +2943,7 @@
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "requires": {
         "env-variable": "0.0.x"
@@ -3773,7 +3773,7 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "figures": {
@@ -10818,7 +10818,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -10832,7 +10832,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "knapsack-pro-cypress": "lib/knapsack-pro-cypress.js"
   },
   "dependencies": {
-    "@knapsack-pro/core": "^1.1.0",
+    "@knapsack-pro/core": "^1.2.0",
     "cypress": "^3.1.5",
     "glob": "^7.1.3",
     "minimist": "^1.2.0"


### PR DESCRIPTION
# Changes
* Update `@knapsack-pro/core` to 1.2.0
* Add example of Semaphore 2.0 config in readme.

Related to: https://github.com/KnapsackPro/knapsack-pro-core-js/pull/11

