### PR TITLE
Reduce data transfer and speed up usage of Knapsack Pro API for Queue Mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -855,9 +855,9 @@
       }
     },
     "@knapsack-pro/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-63kJpA4gEcSLLibQaKGr/nEKY2CZWkKYYKpIU8vtFCRu9ORIjX0k5rdp+0Gsckdm/QmJ/S4F7GxH0HZu+sFWrQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.3.0.tgz",
+      "integrity": "sha512-pnZW/PPM5GE0OkrryxFkRVrtTMBADQrIDguSWonl+nZlw1vmkv6MaquL+z9HYd85IPt0JnvgKROI4NKu5YMq+g==",
       "requires": {
         "axios": "^0.18.0",
         "axios-retry": "^3.1.1",
@@ -1705,7 +1705,7 @@
     },
     "axios": {
       "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
         "follow-redirects": "^1.3.0",
@@ -2943,7 +2943,7 @@
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "requires": {
         "env-variable": "0.0.x"
@@ -3773,7 +3773,7 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "figures": {
@@ -10783,9 +10783,9 @@
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         },
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -10818,7 +10818,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -10832,7 +10832,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "knapsack-pro-cypress": "lib/knapsack-pro-cypress.js"
   },
   "dependencies": {
-    "@knapsack-pro/core": "^1.2.0",
+    "@knapsack-pro/core": "^1.3.0",
     "cypress": "^3.1.5",
     "glob": "^7.1.3",
     "minimist": "^1.2.0"


### PR DESCRIPTION
* Update `@knapsack-pro/core` to 1.3.0. Related to https://github.com/KnapsackPro/knapsack-pro-core-js/pull/12

Don’t send test_files for already initialized Queue. Thanks to that we
reduce data transfer. This also makes requests much faster (even 10
times faster for test suite with 5000 test files).