### PR TITLE
Update @knapsack-pro/core 1.5.0 to add support for GitHub Actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -922,9 +922,9 @@
       }
     },
     "@knapsack-pro/core": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.4.1.tgz",
-      "integrity": "sha512-phOpabQENPtw/+D9lF7mN1lEdCHLSAploL5r2IygM1d3SI+pxB0itIFm7fMe8CszuF5qROW2mDjf0gpPqsSnOg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-pvFeU9nnN009tnwyDGbiHZE7kWIXUjtNxMJCcin8wzRjNQ7b/+DpANSAXGi2/kz+OWx3pj/f7s9mOvAqs0ok2g==",
       "requires": {
         "axios": "0.18.0",
         "axios-retry": "^3.1.2",
@@ -3851,9 +3851,9 @@
       "dev": true
     },
     "fast-safe-stringify": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
-      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fault": {
       "version": "1.0.2",
@@ -4282,9 +4282,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.8.1.tgz",
-      "integrity": "sha512-micCIbldHioIegeKs41DoH0KS3AXfFzgS30qVkM6z/XOE/GJgvmsoc839NUqa1B9udYe9dQxgv7KFwng6+p/dw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
+      "integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
       "requires": {
         "debug": "^3.0.0"
       }
@@ -5975,9 +5975,9 @@
       "dev": true
     },
     "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
     },
     "is-stream": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "knapsack-pro-cypress": "lib/knapsack-pro-cypress.js"
   },
   "dependencies": {
-    "@knapsack-pro/core": "^1.4.1",
+    "@knapsack-pro/core": "^1.5.0",
     "cypress": "^3.1.5",
     "glob": "^7.1.3",
     "minimist": "^1.2.0"


### PR DESCRIPTION
Add support for GitHub Actions as CI provider.

Related changes in `@knapsack-pro/core`: 
https://github.com/KnapsackPro/knapsack-pro-core-js/pull/16