### PR TITLE
fix(bug): When Cypress crashed then exit code should be 1

### DIFF
--- a/src/knapsack-pro-cypress.ts
+++ b/src/knapsack-pro-cypress.ts
@@ -39,6 +39,14 @@ const onSuccess: onQueueSuccessType = async (queueTestFiles: TestFile[]) => {
     spec: testFilePaths,
   });
 
+  // when Cypress crashed
+  if (typeof tests === 'undefined') {
+    return {
+      recordedTestFiles: [],
+      isTestSuiteGreen: false,
+    };
+  }
+
   const recordedTestFiles: TestFile[] = tests.map((test: any) => ({
     path: test.spec.relative,
     time_execution: test.stats.wallClockDuration / 1000,


### PR DESCRIPTION
# Bug description

When Cypress process crashed then `@knapsack-pro/cypress` should return exit code 1 instead of 0 so CI server will know that tests failed.
Returning 0 exit code lead to false positive green CI build on CI server.

# Before fix - How to reproduce the bug

When in `cypress.json` you set an invalid path for `supportFile` then Cypress crashes.

```json
{
  "projectId": "47f44n",
  "supportFile": "cypress/support/index_fake.js"
}
```

Logs with exit code 0:

```
2019-09-26T16:49:44.605Z [@knapsack-pro/core] info: POST https://api-staging.knapsackpro.com/v1/queues/queue

2019-09-26T16:49:47.488Z [@knapsack-pro/core] info: 200 OK

Request ID:
15057154-e096-4cfb-ab41-2b1237ae8e74

Response body:
{ queue_name: '23:8e1654bc6cdcfc9c107aed21c562c1d1',
  build_subset_id: null,
  test_files:
   [ { path: 'cypress/integration/examples/aliasing.spec.js',
       time_execution: null } ] }
The support file is missing or invalid.

Your `supportFile` is set to `/Users/artur/Documents/github/knapsack-pro/knapsack-for-js/cypress-example-kitchensink/cypress/support/index_fake.js`, but either the file is missing or it's invalid. The `supportFile` must be a `.js` or `.coffee` file or, if you're using a preprocessor plugin, it must be supported by that plugin.

Correct your `cypress.json`, create the appropriate file, or set `supportFile` to `false` if a support file is not necessary for your project.

Learn more at https://on.cypress.io/support-file-missing-or-invalid
(node:16103) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'map' of undefined
    at Object.<anonymous> (/Users/artur/Documents/github/knapsack-pro/knapsack-for-js/knapsack-pro-cypress/lib/knapsack-pro-cypress.js:72:43)
    at step (/Users/artur/Documents/github/knapsack-pro/knapsack-for-js/knapsack-pro-cypress/lib/knapsack-pro-cypress.js:44:23)
    at Object.next (/Users/artur/Documents/github/knapsack-pro/knapsack-for-js/knapsack-pro-cypress/lib/knapsack-pro-cypress.js:25:53)
    at fulfilled (/Users/artur/Documents/github/knapsack-pro/knapsack-for-js/knapsack-pro-cypress/lib/knapsack-pro-cypress.js:16:58)
    at <anonymous>
(node:16103) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:16103) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.


$ echo $?
0 <--- this is wrong, it leads to false positive green CI build on CI server
```

# After fix

Now the exit code is 1. CI server knows tests failed.