### PR TITLE
Add support for Codefresh.io CI provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -922,9 +922,9 @@
       }
     },
     "@knapsack-pro/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-pvFeU9nnN009tnwyDGbiHZE7kWIXUjtNxMJCcin8wzRjNQ7b/+DpANSAXGi2/kz+OWx3pj/f7s9mOvAqs0ok2g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-wQ43gfxcMZpq88qCMi1vwX0AyfgDewoxBklPyS/VOAK1YIcg5NculzM9bcORXTPRSpkF7As+Vy7tExtUraSj3Q==",
       "requires": {
         "axios": "0.18.0",
         "axios-retry": "^3.1.2",
@@ -2481,9 +2481,9 @@
       "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
     },
     "colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "colorspace": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "knapsack-pro-cypress": "lib/knapsack-pro-cypress.js"
   },
   "dependencies": {
-    "@knapsack-pro/core": "^1.5.0",
+    "@knapsack-pro/core": "^1.6.0",
     "cypress": "^3.1.5",
     "glob": "^7.1.3",
     "minimist": "^1.2.0"


### PR DESCRIPTION
* Add support for Codefresh.io CI provider
* Update `@knapsack-pro/core` 1.6.0
Related PR https://github.com/KnapsackPro/knapsack-pro-core-js/pull/17