### PR TITLE
Run tests only when they are detected on the disk. Do not run tests when the test file pattern is invalid. Require to set KNAPSACK_PRO_TEST_FILE_PATTERN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -922,11 +922,11 @@
       }
     },
     "@knapsack-pro/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-wQ43gfxcMZpq88qCMi1vwX0AyfgDewoxBklPyS/VOAK1YIcg5NculzM9bcORXTPRSpkF7As+Vy7tExtUraSj3Q==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.6.1.tgz",
+      "integrity": "sha512-HyMIVNZ/pH+f9XvJCQl1k8Le5Wx/4V4eVFl09BU/upAopUiEqcNVJuIpjdB3bo8zl3vIWVXGEa6cO1Rfh7NbOA==",
       "requires": {
-        "axios": "0.18.0",
+        "axios": "0.18.1",
         "axios-retry": "^3.1.2",
         "winston": "^3.1.0"
       }
@@ -1771,12 +1771,19 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
       "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        }
       }
     },
     "axios-retry": {
@@ -4282,11 +4289,11 @@
       }
     },
     "follow-redirects": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
-      "integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
-        "debug": "^3.0.0"
+        "debug": "=3.1.0"
       }
     },
     "for-in": {
@@ -5753,7 +5760,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "knapsack-pro-cypress": "lib/knapsack-pro-cypress.js"
   },
   "dependencies": {
-    "@knapsack-pro/core": "^1.6.0",
+    "@knapsack-pro/core": "^1.6.1",
     "cypress": "^3.1.5",
     "glob": "^7.1.3",
     "minimist": "^1.2.0"

--- a/src/test-files-finder.ts
+++ b/src/test-files-finder.ts
@@ -1,12 +1,25 @@
 import glob = require('glob');
 
-import { TestFile } from '@knapsack-pro/core';
+import { KnapsackProLogger, TestFile } from '@knapsack-pro/core';
 import { EnvConfig } from './env-config';
 
 export class TestFilesFinder {
   public static allTestFiles(): TestFile[] {
-    return glob
+    const testFiles = glob
       .sync(EnvConfig.testFilePattern)
       .map((testFilePath: string) => ({ path: testFilePath }));
+
+    if (testFiles.length === 0) {
+      const knapsackProLogger = new KnapsackProLogger();
+
+      const errorMessage =
+        // tslint:disable-next-line: max-line-length
+        'Test files cannot be found.\nPlease set KNAPSACK_PRO_TEST_FILE_PATTERN matching your test directory structure.\nLearn more: https://github.com/KnapsackPro/knapsack-pro-cypress#how-to-run-tests-only-from-specific-directory';
+
+      knapsackProLogger.error(errorMessage);
+      throw errorMessage;
+    }
+
+    return testFiles;
   }
 }


### PR DESCRIPTION
# Problem

When a user has test files in a non-standard directory then Knapsack Pro can't find test files so the empty array of tests is sent to Knapsack Pro API Queue. API returns an error so Knapsack Pro switches to Fallback Mode and tries to run empty list of tests which crashes Cypress with error.

```
2019-11-22T13:06:08.773Z [@knapsack-pro/core] info: POST https://api-staging.knapsackpro.com/v1/queues/queue

2019-11-22T13:06:13.042Z [@knapsack-pro/core] error: 422 Unprocessable Entity

Request ID:
4b23fc02-d1bc-4de8-975e-b97e260c92f3

Response body:
{ errors: [ { test_files: [ 'parameter is required' ] } ] }

2019-11-22T13:06:13.042Z [@knapsack-pro/core] warn: Fallback Mode has started. We could not connect to Knapsack Pro API. Your tests will be executed based on test file names.

If other CI nodes were able to connect to Knapsack Pro API then you may notice that some of the test files were executed twice across CI nodes. Fallback Mode guarantees each of test files is run at least once as a part of CI build.

Can't run because no spec files were found. <--- THIS IS ERROR FROM CYPRESS

We searched for any files matching this glob pattern: <--- THIS IS ERROR FROM CYPRESS

2019-11-22T13:06:22.754Z [@knapsack-pro/core] info: POST https://api-staging.knapsackpro.com/v1/build_subsets

2019-11-22T13:06:23.448Z [@knapsack-pro/core] info: 201 Created

Request ID:
d59dff37-54b0-4e82-abd8-869b66ad24ed

Response body:
''
```

# Solution

* Do not run tests when the test file pattern is invalid. 
* Show error message about `KNAPSACK_PRO_TEST_FILE_PATTERN` being required.
* Show link to https://github.com/KnapsackPro/knapsack-pro-cypress#how-to-run-tests-only-from-specific-directory

Thanks to this a user who has a test suite in a non-standard directory won't be accidentally running an empty list of tests in Fallback Mode. Users will see a meaningful error with tips on what to do to fix the problem.

# Other changes
* Update `@knapsack-pro/core` to 1.6.1 https://github.com/KnapsackPro/knapsack-pro-core-js/blob/master/CHANGELOG.md#v161-2019-11-04