### PR TITLE
Update cypress dependency to >= 4.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@knapsack-pro/core": "^2.0.0",
-    "cypress": "^4.9.0",
+    "cypress": ">=4.9.0",
     "glob": "^7.1.3",
     "minimist": "^1.2.0"
   },


### PR DESCRIPTION
# Related issue
https://github.com/KnapsackPro/knapsack-pro-cypress/issues/32

