### PR TITLE
When you use --record flag to send data to Cypress Dashboard then generate a unique group name for each set of tests fetched from Knapsack Pro Queue API to make Cypress Dashboard accept recorded data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,44 +668,7 @@ You can pass many of [Cypress CLI arguments](https://docs.cypress.io/guides/guid
 
 ### How to record CI builds in Cypress Dashboard?
 
-You can pass [Cypress CLI arguments](https://docs.cypress.io/guides/guides/command-line.html#cypress-run) to `@knapsack-pro/cypress` and thanks to this send recorded run to [Cypress Dashboard](https://dashboard.cypress.io).
-
-```
-export CYPRESS_RECORD_KEY=your-record-key
-
-$(npm bin)/knapsack-pro-cypress --record
-```
-
-Note when you use `--record` argument then you will see in Cypress Dashboard multiple runs for single CI build. The reason is the fact that `@knapsack-pro/cypress` split test files in dynamic way across CI nodes. It fetches batch of test files from Knapsack Pro API Queue to run it. The batch of test files is shown as single run in Cypress Dashboard.
-
-In order to show single run in Cypress Dashboard correctly you need to group all batches of test files fetched from Knapsack Pro API Queue for particular CI build. You need to pass `--ci-build-id` and `--group` arguments. This works only for paid Cypress plan.
-
-```
-$(npm bin)/knapsack-pro-cypress --record --ci-build-id $CI_BUILD_ID --group @knapsack-pro/cypress
-```
-
-You must use CI build ID variable for your CI provider instead of above example `$CI_BUILD_ID`.
-
-| CI provider    | Environment variable                         |
-| -------------- | -------------------------------------------- |
-| AppVeyor       | `APPVEYOR_BUILD_NUMBER`                      |
-| Bamboo         | `BAMBOO_BUILD_NUMBER`                        |
-| Buildkite      | `BUILDKITE_BUILD_NUMBER`                     |
-| Circle         | `CIRCLE_WORKFLOW_ID`, `CIRCLE_BUILD_NUMBER`  |
-| Cirrus         | `CIRRUS_BUILD_ID`                            |
-| Codeship       | `CI_BUILD_NUMBER`                            |
-| Codeship Basic | `CI_BUILD_NUMBER`                            |
-| Codeship Pro   | `CI_BUILD_ID`                                |
-| Drone          | `DRONE_BUILD_NUMBER`                         |
-| Gitlab         | `CI_PIPELINE_ID`, `CI_JOB_ID`, `CI_BUILD_ID` |
-| Github Actions | `GITHUB_RUN_ID`                              |
-| Heroku         | `HEROKU_TEST_RUN_ID`                         |
-| Jenkins        | `BUILD_NUMBER`                               |
-| Semaphore 1.0  | `SEMAPHORE_BUILD_NUMBER`                     |
-| Semaphore 2.0  | `SEMAPHORE_WORKFLOW_ID`                      |
-| Solano         | `TDDIUM_SESSION_ID`                          |
-| Travis         | `TRAVIS_BUILD_ID`                            |
-| Codefresh.io   | `CF_BUILD_ID`                                |
+https://knapsackpro.com/faq/question/how-to-record-ci-builds-in-cypress-dashboard
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -650,21 +650,11 @@ This project depends on `@knapsack-pro/core`. Please check the [FAQ for `@knapsa
 
 ### How to run tests only from specific directory?
 
-You can set `KNAPSACK_PRO_TEST_FILE_PATTERN="cypress/integration/**/*.{js,jsx,coffee,cjsx}"` and change pattern to match your directory with test files. You can use [glob](https://github.com/isaacs/node-glob) pattern.
-
-If you want to use a few patterns you can do it this way `KNAPSACK_PRO_TEST_FILE_PATTERN="{pattern_1,pattern_2}"`.
+https://knapsackpro.com/faq/question/how-to-run-tests-only-from-specific-directory-in-cypress
 
 ### How to pass command line options?
 
-**UP TO DATE ANSWER:** https://knapsackpro.com/faq/question/how-to-pass-command-line-options-to-cypress
-
-You can pass command line options to Cypress by just passing them to `@knapsack-pro/cypress`. See example:
-
-```
-$(npm bin)/knapsack-pro-cypress --browser chrome
-```
-
-You can pass many of [Cypress CLI arguments](https://docs.cypress.io/guides/guides/command-line.html#cypress-run) to `@knapsack-pro/cypress`.
+https://knapsackpro.com/faq/question/how-to-pass-command-line-options-to-cypress
 
 ### How to record CI builds in Cypress Dashboard?
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1202,6 +1202,12 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
           "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -8853,10 +8859,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",
@@ -9073,7 +9078,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
   "dependencies": {
     "@knapsack-pro/core": "^3.0.1",
     "glob": "^7.1.6",
-    "minimist": "^1.2.5"
+    "minimist": "^1.2.5",
+    "uuid": "^8.3.1"
   },
   "peerDependencies": {
     "cypress": ">=3.0.0 <6.0.0"

--- a/src/cypress-cli.ts
+++ b/src/cypress-cli.ts
@@ -1,4 +1,5 @@
 const minimist = require('minimist');
+const { v4: uuidv4 } = require('uuid');
 
 export class CypressCLI {
   // list should match camelCase args here
@@ -15,5 +16,21 @@ export class CypressCLI {
     return minimist(argv, {
       alias: CypressCLI.alias,
     });
+  }
+
+  public static updateOptions(args: object): object {
+    // If you want to send recorded data to Cypress Dashboard
+    // then we need to generate a unique group name for set of tests fetched
+    // from Knapsack Pro API for each cypress.run execution
+    // Only then Cypress API accepts data
+    // (Cypress not allow to use the same group name within the same CI build)
+    if (args.hasOwnProperty('record')) {
+      return {
+        ...args,
+        group: uuidv4(),
+      };
+    }
+
+    return args;
   }
 }

--- a/src/knapsack-pro-cypress.ts
+++ b/src/knapsack-pro-cypress.ts
@@ -17,8 +17,11 @@ import { CypressCLI } from './cypress-cli';
 
 const cypressCLIOptions = CypressCLI.argvToOptions();
 const knapsackProLogger = new KnapsackProLogger();
+
 knapsackProLogger.debug(
-  `Cypress CLI options:\n${KnapsackProLogger.objectInspect(cypressCLIOptions)}`
+  `Initial Cypress CLI options:\n${KnapsackProLogger.objectInspect(
+    cypressCLIOptions
+  )}`
 );
 
 EnvConfig.loadEnvironmentVariables();
@@ -34,8 +37,16 @@ const onSuccess: onQueueSuccessType = async (queueTestFiles: TestFile[]) => {
   const testFilePaths: string[] = queueTestFiles.map(
     (testFile: TestFile) => testFile.path
   );
+
+  const updatedCypressCLIOptions = CypressCLI.updateOptions(cypressCLIOptions);
+  knapsackProLogger.debug(
+    `Updated Cypress CLI options for the set of tests fetched from Knapsack Pro API:\n${KnapsackProLogger.objectInspect(
+      updatedCypressCLIOptions
+    )}`
+  );
+
   const { runs: tests, totalFailed } = await cypress.run({
-    ...cypressCLIOptions,
+    ...updatedCypressCLIOptions,
     spec: testFilePaths,
   });
 


### PR DESCRIPTION
When you use --record flag to send data to Cypress Dashboard then generate a unique group name for each set of tests fetched from Knapsack Pro Queue API to make Cypress Dashboard accept recorded data.