### PR TITLE
Allow user to disable recording with `--record false` flag

### DIFF
--- a/src/cypress-cli.ts
+++ b/src/cypress-cli.ts
@@ -24,7 +24,7 @@ export class CypressCLI {
     // from Knapsack Pro API for each cypress.run execution
     // Only then Cypress API accepts data
     // (Cypress not allow to use the same group name within the same CI build)
-    if (args.hasOwnProperty('record') && args.record != 'false') {
+    if (args.hasOwnProperty('record') && args.record !== 'false') {
       return {
         ...args,
         group: uuidv4(),

--- a/src/cypress-cli.ts
+++ b/src/cypress-cli.ts
@@ -18,13 +18,13 @@ export class CypressCLI {
     });
   }
 
-  public static updateOptions(args: object): object {
+  public static updateOptions(args: any): object {
     // If you want to send recorded data to Cypress Dashboard
     // then we need to generate a unique group name for set of tests fetched
     // from Knapsack Pro API for each cypress.run execution
     // Only then Cypress API accepts data
     // (Cypress not allow to use the same group name within the same CI build)
-    if (args.hasOwnProperty('record')) {
+    if (args.hasOwnProperty('record') && args.record != 'false') {
       return {
         ...args,
         group: uuidv4(),


### PR DESCRIPTION
# related issue
https://github.com/KnapsackPro/knapsack-pro-cypress/issues/66

# related PR
https://github.com/KnapsackPro/knapsack-pro-cypress/pull/47

# tech note

I verified that if `--record` flag has a value different than `false` then it is considered as `true` and recording is enabled. It means that value `FALSE` is considered as `true` and recording is enabled. The same for value like `f` which is `true`. That is why we use `args.record !== 'false'`