### PR TITLE
[breaking change] Add support for Cypress 10.x

### DIFF
--- a/src/env-config.ts
+++ b/src/env-config.ts
@@ -11,6 +11,6 @@ export class EnvConfig {
       return process.env.KNAPSACK_PRO_TEST_FILE_PATTERN;
     }
 
-    return 'cypress/integration/**/*.{js,jsx,coffee,cjsx}';
+    return 'cypress/e2e/**/*.{js,jsx,coffee,cjsx}';
   }
 }


### PR DESCRIPTION
# breaking changes

This version of `@knapsack-pro/cypress` works only with `Cypress >= 10`.

Changes:

* New default pattern `cypress/e2e/**/*.{js,jsx,coffee,cjsx}` for Cypress 10.x tests location on the disk. The old pattern was `cypress/integration/**/*.{js,jsx,coffee,cjsx}` for `Cypress < 10`.