### PR TITLE
Remove tracking legacy wallClockDuration for Cypress 3.x and 4.x

### DIFF
--- a/src/knapsack-pro-cypress.ts
+++ b/src/knapsack-pro-cypress.ts
@@ -63,10 +63,7 @@ const onSuccess: onQueueSuccessType = async (queueTestFiles: TestFile[]) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const recordedTestFiles: TestFile[] = tests.map((test: any) => ({
     path: test.spec.relative,
-    time_execution:
-      // test.stats.wallClockDuration - Cypress 3.x and 4.x
-      // test.stats.duration - Cypress 5.x
-      (test.stats.wallClockDuration || test.stats.duration) / 1000,
+    time_execution: test.stats.duration / 1000,
   }));
 
   return {


### PR DESCRIPTION
`@knapsack-pro/cypress` [5.0.0 version](https://github.com/KnapsackPro/knapsack-pro-cypress/blob/master/CHANGELOG.md#v500-2022-06-13) supports only Cypress >= 10.x.

We can remove legacy code that was specific to older Cypress versions.

# changes

Remove tracking legacy wallClockDuration for Cypress 3.x and 4.x.