### PR TITLE
Catch an exception from cypress.run to handle UnhandledPromiseRejectionWarning

### DIFF
--- a/src/knapsack-pro-cypress.ts
+++ b/src/knapsack-pro-cypress.ts
@@ -47,10 +47,19 @@ const onSuccess: onQueueSuccessType = async (queueTestFiles: TestFile[]) => {
     )}`,
   );
 
-  const { runs: tests, totalFailed } = await cypress.run({
-    ...updatedCypressCLIOptions,
-    spec: testFilePaths,
-  });
+  const { runs: tests, totalFailed } = await cypress
+    .run({
+      ...updatedCypressCLIOptions,
+      spec: testFilePaths,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .catch((e: any) => {
+      knapsackProLogger.error(
+        `Error from cypress.run:\n${KnapsackProLogger.objectInspect(e)}`,
+      );
+      process.exitCode = 1;
+      throw new Error('cypress.run process failed. See the above logs.');
+    });
 
   // when Cypress crashed
   if (typeof tests === 'undefined') {


### PR DESCRIPTION
* Catch an exception from `cypress.run` to handle UnhandledPromiseRejectionWarning
* throw an error when cypress.run fails
* set process exit code to `1` to ensure CI fails


# related issue

* https://github.com/KnapsackPro/knapsack-pro-cypress/issues/43

# example CI build

CI build that correctly failed after our fix in this PR:
https://app.circleci.com/pipelines/github/KnapsackPro/cypress-example-kitchensink/70/workflows/9e12473e-655c-46d3-84c4-1e23a861d348/jobs/234

(it was triggered by not having Cypress 10.1.0 installed on CI for the kitchensink project).