### PR TITLE
Improvements: make project compile again

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See the [docs](https://docs.knapsackpro.com/cypress/guide/) to get started.
 
 You can use [NVM](https://github.com/nvm-sh/nvm) to manage Node version in development.
 
-- `>= Node 16.15.1 LTS`
+- `>= Node 18.13.0 LTS`
 
 ### Dependencies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@knapsack-pro/core": "^3.2.0",
         "glob": "^8.0.3",
-        "minimatch": "^6.0.0",
+        "minimatch": "^6.0.4",
         "minimist": "^1.2.6",
         "uuid": "^8.3.2"
       },
@@ -8329,9 +8329,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.0.0.tgz",
-      "integrity": "sha512-6c/YhQ/ZnMCtAGMJTuPQlk1Q6ig41qn1laC1H/AU6dIIgurKxxfh0OEALh9V4+vPcy2VC670D46TOGc8dirt6w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.0.4.tgz",
+      "integrity": "sha512-9SQupyyavjdAc1VFjJS/5kdtFtlLAhKSWt7HocG0h/npy626jYrGegSslcM7Xxet5z0U9GOx9YbcpyIjBzn7tA==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -18233,9 +18233,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.0.0.tgz",
-      "integrity": "sha512-6c/YhQ/ZnMCtAGMJTuPQlk1Q6ig41qn1laC1H/AU6dIIgurKxxfh0OEALh9V4+vPcy2VC670D46TOGc8dirt6w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.0.4.tgz",
+      "integrity": "sha512-9SQupyyavjdAc1VFjJS/5kdtFtlLAhKSWt7HocG0h/npy626jYrGegSslcM7Xxet5z0U9GOx9YbcpyIjBzn7tA==",
       "requires": {
         "brace-expansion": "^2.0.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@knapsack-pro/core": "^3.2.0",
-        "glob": "^8.0.3",
+        "glob": "^8.1.0",
         "minimatch": "^6.0.4",
         "minimist": "^1.2.6",
         "uuid": "^8.3.2"
@@ -22,7 +22,7 @@
         "@babel/core": "^7.18.2",
         "@babel/preset-env": "^7.18.2",
         "@babel/register": "^7.17.7",
-        "@types/glob": "^7.2.0",
+        "@types/glob": "^8.0.0",
         "@types/jquery": "^3.5.14",
         "@types/node": "^17.0.41",
         "@typescript-eslint/eslint-plugin": "^5.27.1",
@@ -1964,9 +1964,9 @@
       }
     },
     "node_modules/@types/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.0.0.tgz",
+      "integrity": "sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==",
       "dev": true,
       "dependencies": {
         "@types/minimatch": "*",
@@ -5900,9 +5900,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -13435,9 +13435,9 @@
       }
     },
     "@types/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.0.0.tgz",
+      "integrity": "sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==",
       "dev": true,
       "requires": {
         "@types/minimatch": "*",
@@ -16449,9 +16449,9 @@
       }
     },
     "glob": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@knapsack-pro/core": "^3.2.0",
         "glob": "^8.1.0",
-        "minimatch": "^6.0.4",
+        "minimatch": "^5.1.4",
         "minimist": "^1.2.6",
         "uuid": "^8.3.2"
       },
@@ -6032,17 +6032,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/global-dirs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
@@ -8329,17 +8318,14 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.0.4.tgz",
-      "integrity": "sha512-9SQupyyavjdAc1VFjJS/5kdtFtlLAhKSWt7HocG0h/npy626jYrGegSslcM7Xxet5z0U9GOx9YbcpyIjBzn7tA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.4.tgz",
+      "integrity": "sha512-U0iNYXt9wALljzfnGkhFSy5sAC6/SCR3JrHrlsdJz4kF8MvhTRQNiC59iUi1iqsitV7abrNAJWElVL9pdnoUgw==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -16458,16 +16444,6 @@
         "inherits": "2",
         "minimatch": "^5.0.1",
         "once": "^1.3.0"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
       }
     },
     "glob-parent": {
@@ -18233,9 +18209,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.0.4.tgz",
-      "integrity": "sha512-9SQupyyavjdAc1VFjJS/5kdtFtlLAhKSWt7HocG0h/npy626jYrGegSslcM7Xxet5z0U9GOx9YbcpyIjBzn7tA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.4.tgz",
+      "integrity": "sha512-U0iNYXt9wALljzfnGkhFSy5sAC6/SCR3JrHrlsdJz4kF8MvhTRQNiC59iUi1iqsitV7abrNAJWElVL9pdnoUgw==",
       "requires": {
         "brace-expansion": "^2.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@knapsack-pro/core": "^3.2.0",
-    "glob": "^8.0.3",
+    "glob": "^8.1.0",
     "minimatch": "^6.0.4",
     "minimist": "^1.2.6",
     "uuid": "^8.3.2"
@@ -68,7 +68,7 @@
     "@babel/core": "^7.18.2",
     "@babel/preset-env": "^7.18.2",
     "@babel/register": "^7.17.7",
-    "@types/glob": "^7.2.0",
+    "@types/glob": "^8.0.0",
     "@types/jquery": "^3.5.14",
     "@types/node": "^17.0.41",
     "@typescript-eslint/eslint-plugin": "^5.27.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@knapsack-pro/core": "^3.2.0",
     "glob": "^8.0.3",
-    "minimatch": "^6.0.0",
+    "minimatch": "^6.0.4",
     "minimist": "^1.2.6",
     "uuid": "^8.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@knapsack-pro/core": "^3.2.0",
     "glob": "^8.1.0",
-    "minimatch": "^6.0.4",
+    "minimatch": "^5.1.4",
     "minimist": "^1.2.6",
     "uuid": "^8.3.2"
   },

--- a/src/test-files-finder.ts
+++ b/src/test-files-finder.ts
@@ -22,7 +22,7 @@ export class TestFilesFinder {
       const knapsackProLogger = new KnapsackProLogger();
 
       const errorMessage =
-        'Test files cannot be found.\nPlease make sure that KNAPSACK_PRO_TEST_FILE_PATTERN and KNAPSACK_PRO_TEST_FILE_IGNORE_PATTERN allows for some files in your test directory structure to be matched.\nLearn more: https://knapsackpro.com/faq/question/how-to-run-tests-only-from-specific-directory-in-cypress';
+        'Test files cannot be found.\nPlease make sure that KNAPSACK_PRO_TEST_FILE_PATTERN and KNAPSACK_PRO_TEST_FILE_IGNORE_PATTERN allow for some files in your test directory structure to be matched.\nLearn more: https://knapsackpro.com/faq/question/how-to-run-tests-only-from-specific-directory-in-cypress';
 
       knapsackProLogger.error(errorMessage);
       throw errorMessage;


### PR DESCRIPTION
* [Downgrade minimatch to 5.1.4 in order to compile the project](https://github.com/KnapsackPro/knapsack-pro-cypress/commit/74ab829d7cefae1ec730e8b502feac025a1476a4). minimatch 6.x version does not work due to:

```
[12:50:59] Requiring external module @babel/register
[12:51:00] Using gulpfile ~/Documents/github/knapsack-pro/knapsack-for-js/knapsack-pro-cypress/gulpfile.babel.js
[12:51:00] Starting 'build'...
[12:51:00] Starting 'clean'...
[12:51:00] Finished 'clean' after 16 ms
[12:51:00] Starting 'compile'...
/Users/artur/Documents/github/knapsack-pro/knapsack-for-js/knapsack-pro-cypress/node_modules/@types/glob/index.d.ts(29,42): error TS2694: Namespace '"/Users/artur/Documents/github/knapsack-pro/knapsack-for-js/knapsack-pro-cypress/node_modules/minimatch/dist/cjs/index"' has no exported member 'IOptions'.
/Users/artur/Documents/github/knapsack-pro/knapsack-for-js/knapsack-pro-cypress/node_modules/@types/glob/index.d.ts(74,30): error TS2724: '"/Users/artur/Documents/github/knapsack-pro/knapsack-for-js/knapsack-pro-cypress/node_modules/minimatch/dist/cjs/index"' has no exported member named 'IMinimatch'. Did you mean 'Minimatch'?
src/test-files-finder.ts(13,19): error TS2349: This expression is not callable.
  Type 'typeof import("/Users/artur/Documents/github/knapsack-pro/knapsack-for-js/knapsack-pro-cypress/node_modules/minimatch/dist/cjs/index")' has no call signatures.
TypeScript: 3 semantic errors
TypeScript: emit succeeded (with errors)
[12:51:01] 'compile' errored after 1.11 s
[12:51:01] Error: TypeScript: Compilation failed
    at Output.mightFinish (/Users/artur/Documents/github/knapsack-pro/knapsack-for-js/knapsack-pro-cypress/node_modules/gulp-typescript/release/output.js:130:43)
    at /Users/artur/Documents/github/knapsack-pro/knapsack-for-js/knapsack-pro-cypress/node_modules/gulp-typescript/release/output.js:43:22
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
[12:51:01] 'build' errored after 1.13 s
```

Bug introduced in: https://github.com/KnapsackPro/knapsack-pro-cypress/pull/85

* use Node 18.13.0 LTS
* Update glob and @types/glob package
* Fix typo