### PR TITLE
Search for test files on the disk only if needed by the `@knapsack-pro/core`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@knapsack-pro/core": "^3.3.1",
+        "@knapsack-pro/core": "^4.0.0",
         "glob": "^8.1.0",
         "minimatch": "^5.1.4",
         "minimist": "^1.2.6",
@@ -1897,9 +1897,9 @@
       }
     },
     "node_modules/@knapsack-pro/core": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-3.3.1.tgz",
-      "integrity": "sha512-x0EU3C5G/HE4xL4HVdpVQ17jW7EWvuTNrGv1nJ0gvXOgP3XNmibwbBLN+699px8mAzabrSXjO8QBK36LKKd83A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-4.0.0.tgz",
+      "integrity": "sha512-I7bMzDA9i517BPAObrTUTPLiA0IhXjkHvsy6hBMJ2dwv1Fl6wZG62/KUiXScYq3Vms1kRTKKXW9rU1KQWEkNpg==",
       "dependencies": {
         "axios": "^0.27.2",
         "axios-retry": "^3.2.5",
@@ -13363,9 +13363,9 @@
       }
     },
     "@knapsack-pro/core": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-3.3.1.tgz",
-      "integrity": "sha512-x0EU3C5G/HE4xL4HVdpVQ17jW7EWvuTNrGv1nJ0gvXOgP3XNmibwbBLN+699px8mAzabrSXjO8QBK36LKKd83A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-4.0.0.tgz",
+      "integrity": "sha512-I7bMzDA9i517BPAObrTUTPLiA0IhXjkHvsy6hBMJ2dwv1Fl6wZG62/KUiXScYq3Vms1kRTKKXW9rU1KQWEkNpg==",
       "requires": {
         "axios": "^0.27.2",
         "axios-retry": "^3.2.5",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "knapsack-pro-cypress": "lib/knapsack-pro-cypress.js"
   },
   "dependencies": {
-    "@knapsack-pro/core": "^3.3.1",
+    "@knapsack-pro/core": "^4.0.0",
     "glob": "^8.1.0",
     "minimatch": "^5.1.4",
     "minimist": "^1.2.6",

--- a/src/knapsack-pro-cypress.ts
+++ b/src/knapsack-pro-cypress.ts
@@ -3,6 +3,7 @@
 import {
   KnapsackProCore,
   KnapsackProLogger,
+  testFilesToExecuteType,
   onQueueFailureType,
   onQueueSuccessType,
   TestFile,
@@ -28,11 +29,12 @@ knapsackProLogger.debug(
 
 EnvConfig.loadEnvironmentVariables();
 
-const allTestFiles: TestFile[] = TestFilesFinder.allTestFiles();
+const testFilesToExecute: testFilesToExecuteType = () =>
+  TestFilesFinder.allTestFiles();
 const knapsackPro = new KnapsackProCore(
   clientName,
   clientVersion,
-  allTestFiles,
+  testFilesToExecute,
 );
 
 const onSuccess: onQueueSuccessType = async (queueTestFiles: TestFile[]) => {


### PR DESCRIPTION
# changes 

* Update `@knapsack-pro/core` to 4.0.0 and adjust the codebase to use the new `@knapsack-pro/core` code API 

# related

* https://github.com/KnapsackPro/knapsack-pro-core-js/pull/64