### PR TITLE
Update peerDependencies and update Cypress version

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ You can use [NVM](https://github.com/nvm-sh/nvm) to manage Node versions in deve
 
 If your feature requires code changes in [@knapsack-pro/core](https://github.com/KnapsackPro/knapsack-pro-core-js), please push the `@knapsack-pro/core` to GitHub first. Then you can push changes for `@knapsack-pro/cypress` to ensure the CI will use the latest `@knapsack-pro/core`.
 
-#### Example Cypress test suite
+#### Cypress example test suite
 
-To test `@knapsack-pro/cypress` against a real test suite we use the forked [cypress-example-kitchensink](https://github.com/KnapsackPro/cypress-example-kitchensink/blob/knapsack-pro/README.knapsack-pro.md) project.
+To test `@knapsack-pro/cypress` against a real test suite we use the [cypress-example-test-suite](https://github.com/KnapsackPro/cypress-example-test-suite) project.
 
 ### Publishing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "typescript": "^4.7.3"
       },
       "peerDependencies": {
-        "cypress": ">=10.0.0 <11.0.0"
+        "cypress": ">=10.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@types/node": "^17.0.41",
         "@typescript-eslint/eslint-plugin": "^5.27.1",
         "@typescript-eslint/parser": "^5.27.1",
-        "cypress": "10.1.0",
+        "cypress": "12.6.0",
         "del": "^6.1.1",
         "eslint": "^7.32.0",
         "eslint-config-airbnb-base": "^15.0.0",
@@ -3735,9 +3735,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.1.0.tgz",
-      "integrity": "sha512-aQ4JVZVib4Xd9FZW8IRZfKelUvqF4y5A+oUbNvn8TlsBmEfIg3m5Xd6Mt6PVU/jHiVJ9Psl905B3ZPnrDcmyuQ==",
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
+      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3758,9 +3758,9 @@
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "enquirer": "^2.3.6",
-        "eventemitter2": "^6.4.3",
+        "eventemitter2": "6.4.7",
         "execa": "4.1.0",
         "executable": "^4.1.1",
         "extract-zip": "2.0.1",
@@ -3788,7 +3788,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
@@ -4876,9 +4876,9 @@
       }
     },
     "node_modules/eventemitter2": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.5.tgz",
-      "integrity": "sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==",
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
+      "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
       "dev": true
     },
     "node_modules/execa": {
@@ -13916,9 +13916,9 @@
       }
     },
     "cypress": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.1.0.tgz",
-      "integrity": "sha512-aQ4JVZVib4Xd9FZW8IRZfKelUvqF4y5A+oUbNvn8TlsBmEfIg3m5Xd6Mt6PVU/jHiVJ9Psl905B3ZPnrDcmyuQ==",
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
+      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -13938,9 +13938,9 @@
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "enquirer": "^2.3.6",
-        "eventemitter2": "^6.4.3",
+        "eventemitter2": "6.4.7",
         "execa": "4.1.0",
         "executable": "^4.1.1",
         "extract-zip": "2.0.1",
@@ -14802,9 +14802,9 @@
       "dev": true
     },
     "eventemitter2": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.5.tgz",
-      "integrity": "sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==",
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
+      "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
       "dev": true
     },
     "execa": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/node": "^17.0.41",
     "@typescript-eslint/eslint-plugin": "^5.27.1",
     "@typescript-eslint/parser": "^5.27.1",
-    "cypress": "10.1.0",
+    "cypress": "12.6.0",
     "del": "^6.1.1",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "cypress": ">=10.0.0 <11.0.0"
+    "cypress": ">=10.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
     "runner",
     "CI"
   ],
-  "author": "Knapsack Pro <support@knapsackpro.com> (https://knapsackpro.com)",
+  "author": {
+    "name": "Knapsack Sp. z o.o.",
+    "email": "support@knapsackpro.com",
+    "url": "https://knapsackpro.com"
+  },
   "contributors": [
     {
       "name": "Artur Trzop",


### PR DESCRIPTION
# changes

* Update peerDependencies to not lock the max Cypress version
* Update Cypress version in devDependencies
* We created a new Cypress example test suite for testing purposes: https://github.com/KnapsackPro/cypress-example-test-suite
  * We deprecated the fork of [cypress-example-kitchensink](https://github.com/KnapsackPro/cypress-example-kitchensink) in favour of our own [Cypress example test suite](https://github.com/KnapsackPro/cypress-example-test-suite). It's easier to maintain it.