### PR TITLE
Permalinks

### DIFF
--- a/src/test-files-finder.ts
+++ b/src/test-files-finder.ts
@@ -3,6 +3,7 @@ import minimatch = require('minimatch');
 
 import { KnapsackProLogger, TestFile } from '@knapsack-pro/core';
 import { EnvConfig } from './env-config';
+import * as Urls from './urls';
 
 export class TestFilesFinder {
   public static allTestFiles(): TestFile[] {
@@ -21,8 +22,7 @@ export class TestFilesFinder {
     if (testFiles.length === 0) {
       const knapsackProLogger = new KnapsackProLogger();
 
-      const errorMessage =
-        'Test files cannot be found.\nPlease make sure that KNAPSACK_PRO_TEST_FILE_PATTERN and KNAPSACK_PRO_TEST_FILE_IGNORE_PATTERN allow for some files in your test directory structure to be matched.\nLearn more: https://knapsackpro.com/faq/question/how-to-run-tests-only-from-specific-directory-in-cypress';
+      const errorMessage = `Test files cannot be found.\nPlease make sure that KNAPSACK_PRO_TEST_FILE_PATTERN and KNAPSACK_PRO_TEST_FILE_IGNORE_PATTERN allow for some files in your test directory structure to be matched.\nLearn more: ${Urls.NO_TESTS_FOUND}`;
 
       knapsackProLogger.error(errorMessage);
       throw errorMessage;

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -1,0 +1,2 @@
+export const NO_TESTS_FOUND =
+  'https://knapsackpro.com/perma/cypress/no-tests-found';


### PR DESCRIPTION
Same as https://github.com/KnapsackPro/knapsack_pro-ruby/pull/187

The redirect is deployed to production, so you can already tests the link.

See also
- https://github.com/KnapsackPro/knapsack-pro-jest/pull/67
- https://github.com/KnapsackPro/knapsack-pro-api/pull/634